### PR TITLE
a few of set commands for the PIP

### DIFF
--- a/example/PCM60x/calls.json
+++ b/example/PCM60x/calls.json
@@ -33,37 +33,25 @@
     },
     "device_rated_information": {
       "command": "QPIRI",
-      "influx": false,
+      "influx": true,
       "cache": true,
       "crc16": true,
       "response": {
-        "grid_rating_voltage": 1,
-        "grid_rating_current": 1,
-        "ac_output_rating_voltage": 1,
-        "ac_output_rating_frecuency": 1,
-        "ac_output_rating_current": 1,
-        "ac_output_rating_apparent_power": 1,
-        "ac_output_rating_active_power": 1,
-        "battery_rating_voltage": 1,
-        "battery_recharge_voltage": 1,
-        "battery_under_voltage": 1,
-        "battery_bulk_voltage": 1,
-        "battery_float_voltage": 1,
+        "max_output_power": 1,
+        "nominal_battery_voltage": 1,
+        "nominal_charging_current": 1,
+        "absorption_voltage_per_unit": 1,
+        "float_voltage_per_unit": 1,
         "battery_type": 1,
-        "current_max_ac_charging": 1,
-        "current_max_charging_current": 1,
-        "input_voltage_range": 1,
-        "output_source_priority": 1,
-        "charger_source_priority": 1,
-        "parallel_max_num": 1,
-        "machine_type": 1,
-        "topology": 1,
-        "output_mode": 1,
-        "battery_re_discharge_voltage": 1,
-        "pv_condition": 1,
-        "pv_power_balance": 1
+        "remote_battery_voltage_detect": 1,
+        "battery_temperature_compensation": 1,
+        "remote_temperature_detect": 1,
+        "battery_rated_voltage_set": 1,
+        "piece_of_battery_in_serial": 1,
+        "battery_low_warning_voltage": 1,
+        "battery_low_shutdown_detect": 1
       }
-    }
+
   },
   "set_config": {
     "start_bit": "",
@@ -80,20 +68,27 @@
     "response_header_length": 0
   },
   "set": {
-    "feeding_grid_power_calibration":{
-      "command": "S012FPADJ",
+    "bulk_charging" : {
+      "command" : "PBAV",
+      "crc16": true,
       "variables": {
-        "feeding_grid_derection": [1, 0, 1],
-        "feeding_grid_calibration_power": [4, 0, 999]
+        "voltage": ""
       }
     },
-    "f1": {
-      "command": "S013FP",
-      "hide": true,
+    "float_charging" : {
+      "command" : "PBFV",
+      "crc16": true,
       "variables": {
-        "fase": "",
-        "watt": [4, 0, 999]
+        "voltage": ""
+      }
+    },
+    "max_charging": {
+      "command" : "MCHGC0",
+      "crc16": true,
+      "variables" : {
+        "current" : ""
       }
     }
+
   }
 }

--- a/example/PCM60x/session.json
+++ b/example/PCM60x/session.json
@@ -13,13 +13,41 @@
       "name": "general_status",
       "config": "query_config",
       "command": "query/general_status",
-      "interval": 3000,
+      "interval": 5000,
       "max": 0,
       "influx": true,
       "callback": "general_status"
+    },
+    {
+      "name": "device_rated_information",
+      "config": "query_config",
+      "command": "query/device_rated_information",
+      "interval": 120000,
+      "max": 0,
+      "influx": true
     }
-  ], 
+  ],
+  "QuickCommands": {
+    "bulk_charging": {
+      "command": "set/bulk_charging",
+      "config": "set_config",
+      "description" : "Set battery bulk (constant voltage) charging voltage, requires parameter 'voltage'"
+    },
+    "float_charging": {
+      "command": "set/float_charging",
+      "config": "set_config",
+      "description" : "Set battery float charging voltage, requires parameter 'voltage'"
+    },
+    "max_charging": {
+      "command": "set/max_charging",
+      "config": "set_config",
+      "description" : "Set max charging current, requires parameter 'current'"
+    }
+  },
+
+  "ListenOn": ["bulk_charging","float_charging","max_charging"],
+
   "OnInit": {
-    "StartInterval": ["general_status"]
+    "StartInterval": ["general_status","device_rated_information"]
   }
 }

--- a/example/PIP4084/calls.json
+++ b/example/PIP4084/calls.json
@@ -13,7 +13,7 @@
   "query": {
     "general_status": {
       "hide": false,
-      "influx": false,
+      "influx": true,
       "cache": true,
       "command": "QPIGS",
       "crc16": true,
@@ -89,19 +89,60 @@
     "response_header_length": 0
   },
   "set": {
-    "feeding_grid_power_calibration":{
-      "command": "S012FPADJ",
+    "output_source_priority" : {
+      "command" : "POP",
+      "crc16": true,
       "variables": {
-        "feeding_grid_derection": [1, 0, 1],
-        "feeding_grid_calibration_power": [4, 0, 999]
+        "source": ""
       }
     },
-    "f1": {
-      "command": "S013FP",
-      "hide": true,
-      "variables": {
-        "fase": "",
-        "watt": [4, 0, 999]
+    "charger_priority": {
+      "command" : "PCP",
+      "crc16": true,
+      "variables" : {
+        "source" : ""
+      }
+    },
+    "bulk_charging": {
+      "command" : "PCVV",
+      "crc16": true,
+      "variables" : {
+        "voltage" : ""
+      }
+    },
+    "float_charging": {
+      "command" : "PBFT",
+      "crc16": true,
+      "variables" : {
+        "voltage" : ""
+      }
+    },
+    "utility_max_charging": {
+      "command" : "MUCHGC0",
+      "crc16": true,
+      "variables" : {
+        "current" : ""
+      }
+    },
+    "max_charging": {
+      "command" : "MCHGC0",
+      "crc16": true,
+      "variables" : {
+        "current" : ""
+      }
+    },
+    "back_to_grid": {
+      "command" : "PBCV",
+      "crc16": true,
+      "variables" : {
+        "voltage" : ""
+      }
+    },
+    "back_to_battery": {
+      "command" : "PBDV",
+      "crc16": true,
+      "variables" : {
+        "voltage" : ""
       }
     }
   }

--- a/example/PIP4084/package.json
+++ b/example/PIP4084/package.json
@@ -1,6 +1,6 @@
 {
   "name": "solar-sis_pip",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "dependencies": {
     "solar-sis": "latest"
   }

--- a/example/PIP4084/session.json
+++ b/example/PIP4084/session.json
@@ -25,7 +25,53 @@
       "max": 0,
       "influx": true
     }
-  ], 
+  ],
+  "QuickCommands": {
+    "output_source_priority": {
+      "command": "set/output_source_priority",
+      "config": "set_config",
+      "description" : "Set output source priority, requires parameter 'source': 00 for utility first, 01 for solar first, 02 for SBU priority "
+    },
+    "charger_priority": {
+      "command": "set/charger_priority",
+      "config": "set_config",
+      "description" : ["Set device charger priority, requires parameter 'source'",
+                       "For HS: 00 for utility first, 01 for solar first, 02 for solar and utility, 03 for only solar charging",
+                       "For MS: 00 for utility first, 01 for solar first, 03 for only solar charging"]
+    },
+    "bulk_charging": {
+      "command": "set/bulk_charging",
+      "config": "set_config",
+      "description" : "Set battery bulk (constant voltage) charging voltage, requires parameter 'voltage' 48.0V ~ 58.4V for 48V unit, it cannot be set lower than float voltage"
+    },
+    "float_charging": {
+      "command": "set/float_charging",
+      "config": "set_config",
+      "description" : "Set battery float charging voltage, requires parameter 'voltage' 48.0V ~ 58.4V for 48V unit"
+    },
+    "utility_max_charging": {
+      "command": "set/utility_max_charging",
+      "config": "set_config",
+      "description" : "Set utility max charging current, requires parameter 'current'"
+    },
+    "max_charging": {
+      "command": "set/max_charging",
+      "config": "set_config",
+      "description" : "Set max charging current, requires parameter 'current'"
+    },
+    "back_to_grid": {
+      "command": "set/back_to_grid",
+      "config": "set_config",
+      "description" : "Set battery recharge voltage (back to grid), requires parameter 'voltage', check your model's manual for allowed values"
+    },
+    "back_to_battery": {
+      "command": "set/back_to_battery",
+      "config": "set_config",
+      "description" : "Set battery re-discharge voltage (back to battery), requires parameter 'voltage', check your model's manual for allowed values"
+    }
+  },
+
+  "ListenOn": ["output_source_priority","charger_priority","bulk_charging","float_charging","utility_max_charging","max_charging","back_to_grid","back_to_battery"],
   "OnInit": {
     "StartInterval": ["general_status", "device_rated_information"]
   }

--- a/index.js
+++ b/index.js
@@ -240,6 +240,9 @@ function MergeDataArray (json, queryValues) {
 function GetCrc16 (str) {
   var crc = "";
   Buffer.from(CRC16(str).toString(16), 'hex').forEach((b) => {
+    if (b==10 || b==13 || b==40) {
+        b++;
+    }
     crc += String.fromCharCode(b);
   });
 	return crc;


### PR DESCRIPTION
Hi guys,

here are changes to allow a few of the set commands for the PIP4048

-output_source_priority
-charger_priority
-bulk_charging
-float_charging
-utility_max_charging
-max_charging
-back_to_grid
-back_to_battery

these are the ones I mainly need for my daily use, so it would be great if you can review them and accept them to the main repository.

There is also a change to the GetCrc16 function because the PIP requires a bit of modified behaviour, otherwise it will not work. 
It took me a bit of time to figure this out, had to search on the forums.aeva.asn.au thread in order to find out that the PIP requires special crc16 building. 
You can check out details on this post:
http://forums.aeva.asn.au/viewtopic.php?f=31&t=4332&p=53777&hilit=crc.c#p53760

Basically if the character is one of 0x28,0x0d,0x0a it must be +1 in order to work.

I don't know if this change will work also on other MPP hardware (mainly the MPI Hybrid), so if one of you guys could check this out and confirm that it still works would be great.
Please note that not every command generates a crc which includes one of these characters, so in order to verify that the modified crc16 still works for the MPI, it needs to be checked with a command that falls in this condition. For example on the PIP this was the case for the POP02 command (original crc : 0xE2,0x0A,0x0D ; modified crc in order to work: 0xE2,0x0B,0x0D )

If it does not work for the MPI, it will require for us to use a different crc16 function for the PIP than for the rest. If this is the case, I can prepare code to the index.js to support this. Just let me know.

I hope these changes will be welcomed by you, even if you don't need this specific features yourselves, maybe somebody else will find it useful.
And thanks for all the effort you put in making this code public.
Take care and have sun.
