### PR TITLE
added support fpr UB2000 LiFePo4 Batteries from PylonTech

### DIFF
--- a/example/MPI10kWHybrid/package.json
+++ b/example/MPI10kWHybrid/package.json
@@ -2,6 +2,7 @@
   "name": "solar-sis_mpi",
   "version": "1.0.0",
   "dependencies": {
-    "solar-sis": "latest"
+    "solar-sis": "latest",
+    "serialport": "4.0.7"
   }
 }

--- a/example/PIP4084/calls.json
+++ b/example/PIP4084/calls.json
@@ -40,6 +40,27 @@
         "charging_scc_acc": ["device_status", "8", "7", "8"]
       }
     },
+    "extended_status": {
+      "hide": false,
+      "influx": true,
+      "cache": true,
+      "command": "QPIGS2",
+      "crc16": true,
+      "response": {
+        "pv_input_current_2": 1,
+        "pv_input_voltage_2": 1,
+        "battery_voltage_from_scc_2": 1,
+        "pv_charging_power_2": 1,
+        "device_status_2": 1,
+        "ac_charging_current": 1,
+        "ac_charging_power": 1,
+        "pv_input_current_3": 1,
+        "pv_input_voltage_3": 1,
+        "battery_voltage_from_scc_3": 1,
+        "pv_charging_power_3": 1,
+        "pv_total_charging_power": 1
+      }
+    },
     "device_rated_information": {
       "command": "QPIRI",
       "influx": true,

--- a/example/PIP4084/package.json
+++ b/example/PIP4084/package.json
@@ -2,6 +2,7 @@
   "name": "solar-sis_pip",
   "version": "1.0.1",
   "dependencies": {
-    "solar-sis": "latest"
+    "solar-sis": "latest",
+    "serialport": "4.0.7"
   }
 }

--- a/example/US2000B/calls.json
+++ b/example/US2000B/calls.json
@@ -1,0 +1,223 @@
+{
+  "query_config": {
+    "start_bit": "",
+    "command_type": "P",
+    "response_type": "D",
+    "data_length_bits": 3,
+    "seperator": " ",
+    "ending_character": "\r",
+    "crc_length": 2,
+    "response_start": "~",
+    "response_header_length": 14
+  },
+  "query": {
+    "get_analog_value": {
+      "command": "~20014642E002FFFD0A",
+      "influx": true,
+      "cache": true,
+      "LENID": 2,
+      "crc16": false,
+      "variables": {
+        "Command": 1
+      },
+      "response": {
+        "Ammount_of_Pack": 1,
+        "Cells_count": 1,
+        "Cell1_voltage": -2,
+        "Cell2_voltage": -2,
+        "Cell3_voltage": -2,
+        "Cell4_voltage": -2,
+        "Cell5_voltage": -2,
+        "Cell6_voltage": -2,
+        "Cell7_voltage": -2,
+        "Cell8_voltage": -2,
+        "Cell9_voltage": -2,
+        "Cell10_voltage": -2,
+        "Cell11_voltage": -2,
+        "Cell12_voltage": -2,
+        "Cell13_voltage": -2,
+        "Cell14_voltage": -2,
+        "Cell15_voltage": -2,
+        "Temperature_count": 1,
+        "Temperature_1": -2,
+        "Temperature_2": -2,
+        "Temperature_3": -2,
+        "Temperature_4": -2,
+        "Temperature_5": -2,
+        "Pack_current": -2,
+        "Pack_voltage": 2,
+        "Pack_remains_mAh": 2,
+        "User_defined": 1,
+        "Pack_total_mAh": 2,
+        "Pack_cycle": 2,
+        "Cells_count_P2": 1,
+        "Cell1_voltage_P2": -2,
+        "Cell2_voltage_P2": -2,
+        "Cell3_voltage_P2": -2,
+        "Cell4_voltage_P2": -2,
+        "Cell5_voltage_P2": -2,
+        "Cell6_voltage_P2": -2,
+        "Cell7_voltage_P2": -2,
+        "Cell8_voltage_P2": -2,
+        "Cell9_voltage_P2": -2,
+        "Cell10_voltage_P2": -2,
+        "Cell11_voltage_P2": -2,
+        "Cell12_voltage_P2": -2,
+        "Cell13_voltage_P2": -2,
+        "Cell14_voltage_P2": -2,
+        "Cell15_voltage_P2": -2,
+        "Temperature_count_P2": 1,
+        "Temperature_1_P2": -2,
+        "Temperature_2_P2": -2,
+        "Temperature_3_P2": -2,
+        "Temperature_4_P2": -2,
+        "Temperature_5_P2": -2,
+        "Pack_current_P2": -2,
+        "Pack_voltage_P2": 2,
+        "Pack_remains_mAh_P2": 2,
+        "User_defined_P2": 1,
+        "Pack_total_mAh_P2": 2,
+        "Pack_cycle_P2": 2,
+        "Cells_count_P3": 1,
+        "Cell1_voltage_P3": -2,
+        "Cell2_voltage_P3": -2,
+        "Cell3_voltage_P3": -2,
+        "Cell4_voltage_P3": -2,
+        "Cell5_voltage_P3": -2,
+        "Cell6_voltage_P3": -2,
+        "Cell7_voltage_P3": -2,
+        "Cell8_voltage_P3": -2,
+        "Cell9_voltage_P3": -2,
+        "Cell10_voltage_P3": -2,
+        "Cell11_voltage_P3": -2,
+        "Cell12_voltage_P3": -2,
+        "Cell13_voltage_P3": -2,
+        "Cell14_voltage_P3": -2,
+        "Cell15_voltage_P3": -2,
+        "Temperature_count_P3": 1,
+        "Temperature_1_P3": -2,
+        "Temperature_2_P3": -2,
+        "Temperature_3_P3": -2,
+        "Temperature_4_P3": -2,
+        "Temperature_5_P3": -2,
+        "Pack_current_P3": -2,
+        "Pack_voltage_P3": 2,
+        "Pack_remains_mAh_P3": 2,
+        "User_defined_P3": 1,
+        "Pack_total_mAh_P3": 2,
+        "Pack_cycle_P3": 2,
+        "Cells_count_P4": 1,
+        "Cell1_voltage_P4": -2,
+        "Cell2_voltage_P4": -2,
+        "Cell3_voltage_P4": -2,
+        "Cell4_voltage_P4": -2,
+        "Cell5_voltage_P4": -2,
+        "Cell6_voltage_P4": -2,
+        "Cell7_voltage_P4": -2,
+        "Cell8_voltage_P4": -2,
+        "Cell9_voltage_P4": -2,
+        "Cell10_voltage_P4": -2,
+        "Cell11_voltage_P4": -2,
+        "Cell12_voltage_P4": -2,
+        "Cell13_voltage_P4": -2,
+        "Cell14_voltage_P4": -2,
+        "Cell15_voltage_P4": -2,
+        "Temperature_count_P4": 1,
+        "Temperature_1_P4": -2,
+        "Temperature_2_P4": -2,
+        "Temperature_3_P4": -2,
+        "Temperature_4_P4": -2,
+        "Temperature_5_P4": -2,
+        "Pack_current_P4": -2,
+        "Pack_voltage_P4": 2,
+        "Pack_remains_mAh_P4": 2,
+        "User_defined_P4": 1,
+        "Pack_total_mAh_P4": 2,
+        "Pack_cycle_P4": 2
+      },
+      "MQTTConfig": {
+        "Pack_current": 1,
+        "Pack_current_P2": 1,
+        "Pack_current_P3": 1,
+        "Pack_current_P4": 1,
+        "Pack_remains_mAh": 2,
+        "Pack_remains_mAh_P2": 2,
+        "Pack_remains_mAh_P3": 2,
+        "Pack_remains_mAh_P4": 2
+      }
+    }
+  },
+  "set_config": {
+    "start_bit": "",
+    "command_type": "S",
+    "response_type": "",
+    "data_length_bits": 0,
+    "seperator": " ",
+    "ending_character": "\r",
+    "crc_length": 2,
+    "crc16":true,
+    "response_accept_command": 1,
+    "response_refuse_command": 0,
+    "variable_length_fillout": "0",
+    "response_start": "(",
+    "response_header_length": 0
+  },
+  "set": {
+    "output_source_priority" : {
+      "command" : "POP",
+      "crc16": true,
+      "variables": {
+        "source": ""
+      }
+    },
+    "charger_priority": {
+      "command" : "PCP",
+      "crc16": true,
+      "variables" : {
+        "source" : ""
+      }
+    },
+    "bulk_charging": {
+      "command" : "PCVV",
+      "crc16": true,
+      "variables" : {
+        "voltage" : ""
+      }
+    },
+    "float_charging": {
+      "command" : "PBFT",
+      "crc16": true,
+      "variables" : {
+        "voltage" : ""
+      }
+    },
+    "utility_max_charging": {
+      "command" : "MUCHGC0",
+      "crc16": true,
+      "variables" : {
+        "current" : ""
+      }
+    },
+    "max_charging": {
+      "command" : "MCHGC0",
+      "crc16": true,
+      "variables" : {
+        "current" : ""
+      }
+    },
+    "back_to_grid": {
+      "command" : "PBCV",
+      "crc16": true,
+      "variables" : {
+        "voltage" : ""
+      }
+    },
+    "back_to_battery": {
+      "command" : "PBDV",
+      "crc16": true,
+      "variables" : {
+        "voltage" : ""
+      }
+    }
+  }
+}

--- a/example/US2000B/package.json
+++ b/example/US2000B/package.json
@@ -2,6 +2,7 @@
   "name": "solar-sis_pylon",
   "version": "1.0.1",
   "dependencies": {
-    "solar-sis": "latest"
+    "solar-sis": "latest",
+    "serialport": "4.0.7"
   }
 }

--- a/example/US2000B/package.json
+++ b/example/US2000B/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "solar-sis_pylon",
+  "version": "1.0.1",
+  "dependencies": {
+    "solar-sis": "latest"
+  }
+}

--- a/example/US2000B/project.js
+++ b/example/US2000B/project.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var mpi = require("pylonconnect");
+var mpi = require("../../index");
 
 var mqtt = require('mqtt')
 var client  = mqtt.connect('mqtt://localhost')
@@ -51,6 +51,34 @@ function MyMpiCallbacks () {
   
   this.callback_f1 = function (qc, data, arr) {
     myMpi.SendQuickCommand("feeding_grid_power_calibration");
+  }
+
+  this.customMerge = function(json, queryValues) {
+    var c = 0;
+    var respvalue = 0;
+    var ByteNum = 0;
+    //console.log('queryvalues: ' + JSON.stringify(queryValues));
+    var data = queryValues[0]
+    var s = JSON.parse(JSON.stringify(json), (key, value) => {
+      if (typeof value === 'number') {
+        if (value > 0) {
+          ByteNum = value;
+          respvalue = parseInt(data.substring(c, c+2*ByteNum),16);
+          //console.log("key: " + key + " value: " + value + ' c: ' + c + ' ByteNum: ' + ByteNum + ' respvalue: ' + respvalue);
+        }
+        else {
+          ByteNum = -value;
+          respvalue = parseInt(data.substring(c, c+2*ByteNum),16);
+          if (respvalue > 0x7FFF) respvalue = respvalue - 0xFFFF;
+          //console.log("key: " + key + " value: " + value + ' c: ' + c + ' ByteNum: ' + ByteNum + ' respvalue: ' + respvalue);
+        }
+        c+= 2*ByteNum;
+        return respvalue;
+      }
+      else return value;
+    });
+
+    return s;
   }
 }
 

--- a/example/US2000B/project.js
+++ b/example/US2000B/project.js
@@ -1,0 +1,59 @@
+'use strict';
+
+var mpi = require("pylonconnect");
+
+var mqtt = require('mqtt')
+var client  = mqtt.connect('mqtt://localhost')
+
+function MyMpiCallbacks () {
+  var fr = 0;
+  var fs = 0;
+  var ft = 0;
+
+  this.power_status = function (qc, data, arr, json, influx) {
+    //console.log("mpi_power: influx : " + influx);
+    //mpi.SendDataToInflux('mpi_power ' + influx);
+
+    client.publish('solar/pylon', (Number(arr[0]) + Number(arr[1])).toString());
+  }
+
+  this.feeding_grid_power_calibration = function (qc, data, arr) {
+    //console.log("feeding_grid_power_calibration: " + data);
+    //console.log("feeding_grid_power_calibration: arr: " + arr);
+
+    fr = arr[3];
+    fs = arr[5];
+    ft = arr[7];
+
+    console.log("fr: " + fr + " fs: " + fs + " ft: " + ft);
+
+    if (data) {
+      mpi.SendDataToInflux('mpi_calibration fas_r=' + fr + ',fas_s=' + fs + ',fas_t=' + ft);
+    }
+  }
+
+  this.before_f1 = function (values) {
+    console.log("fr: " + fr + " fs: " + fs + " ft: " + ft);
+  
+    var watt = values.w;
+    var fase = values.f;
+  
+    if (values.a == 1) {
+      if (fase == 'R') { watt = Number(fr) + Number(watt);}
+      if (fase == 'S') { watt = Number(fs) + Number(watt);}
+      if (fase == 'T') { watt = Number(ft) + Number(watt);}
+    }
+  
+    console.log('watt: ' + watt + ' fase:' + fase);
+  
+    return ({"fase" : fase + "ADJ1", "watt" : watt});
+  }
+  
+  this.callback_f1 = function (qc, data, arr) {
+    myMpi.SendQuickCommand("feeding_grid_power_calibration");
+  }
+}
+
+var myMpi = new mpi.mpi();
+var callbacks = new MyMpiCallbacks();
+myMpi.init(callbacks);

--- a/example/US2000B/session.json
+++ b/example/US2000B/session.json
@@ -1,0 +1,71 @@
+{
+  "serial_port": "/dev/ttyUSB0",
+  "serial_baudrate": 1200,
+  "serial_queue_delay": 200,
+  "serial_parsers_readline": "\r",
+  "serial_restart_threshold": 10000,
+  "serial_clear_command_queue_on_restart": true,
+  "http_port": 3003,
+  "influx_pre_header": "pyl_",
+  "MQTT_pre_header": "pylon/",
+  "influxUrl": "http://127.0.0.1:8086/write?db=pylonbat&precision=s",
+  "IntervalCommands": [
+    {
+      "name": "get_analog_value",
+      "config": "query_config",
+      "command": "query/get_analog_value",
+      "interval": 3000,
+      "max": 0,
+      "influx": true
+    }
+  ],
+  "QuickCommands": {
+    "output_source_priority": {
+      "command": "set/output_source_priority",
+      "config": "set_config",
+      "description" : "Set output source priority, requires parameter 'source': 00 for utility first, 01 for solar first, 02 for SBU priority "
+    },
+    "charger_priority": {
+      "command": "set/charger_priority",
+      "config": "set_config",
+      "description" : ["Set device charger priority, requires parameter 'source'",
+                       "For HS: 00 for utility first, 01 for solar first, 02 for solar and utility, 03 for only solar charging",
+                       "For MS: 00 for utility first, 01 for solar first, 03 for only solar charging"]
+    },
+    "bulk_charging": {
+      "command": "set/bulk_charging",
+      "config": "set_config",
+      "description" : "Set battery bulk (constant voltage) charging voltage, requires parameter 'voltage' 48.0V ~ 58.4V for 48V unit, it cannot be set lower than float voltage"
+    },
+    "float_charging": {
+      "command": "set/float_charging",
+      "config": "set_config",
+      "description" : "Set battery float charging voltage, requires parameter 'voltage' 48.0V ~ 58.4V for 48V unit"
+    },
+    "utility_max_charging": {
+      "command": "set/utility_max_charging",
+      "config": "set_config",
+      "description" : "Set utility max charging current, requires parameter 'current'"
+    },
+    "max_charging": {
+      "command": "set/max_charging",
+      "config": "set_config",
+      "description" : "Set max charging current, requires parameter 'current'"
+    },
+    "back_to_grid": {
+      "command": "set/back_to_grid",
+      "config": "set_config",
+      "description" : "Set battery recharge voltage (back to grid), requires parameter 'voltage', check your model's manual for allowed values"
+    },
+    "back_to_battery": {
+      "command": "set/back_to_battery",
+      "config": "set_config",
+      "description" : "Set battery re-discharge voltage (back to battery), requires parameter 'voltage', check your model's manual for allowed values"
+    }
+  },
+
+  "ListenOn": ["output_source_priority","charger_priority","bulk_charging","float_charging","utility_max_charging","max_charging","back_to_grid","back_to_battery"],
+  "OnInit": {
+    "StartInterval": ["general_status", "device_rated_information"]
+  }
+}

--- a/example/US2000B/session.json
+++ b/example/US2000B/session.json
@@ -8,7 +8,9 @@
   "http_port": 3003,
   "influx_pre_header": "pyl_",
   "MQTT_pre_header": "pylon/",
-  "influxUrl": "http://127.0.0.1:8086/write?db=pylonbat&precision=s",
+  "influxUrl": "http://localhost:8086/write?db=powerwall&precision=s",
+  "influxUser": "user",
+  "influxPassword": "password",
   "IntervalCommands": [
     {
       "name": "get_analog_value",
@@ -16,7 +18,8 @@
       "command": "query/get_analog_value",
       "interval": 3000,
       "max": 0,
-      "influx": true
+      "influx": true,
+      "customMerge": "customMerge"
     }
   ],
   "QuickCommands": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "fs": "latest",
     "npmdatelog": "latest",
     "request": "latest",
-    "serialport": "latest",
+    "serialport": "4.0.7",
     "influx": "latest",
     "mqtt": "latest",
     "@serialport/parser-readline": "latest"


### PR DESCRIPTION
This adds support for PylonTach LiFePo4 Batteries and includes the following:
- fixed serialport to version 4.0.7
- support for custom parsers